### PR TITLE
Search forklineage and microg for compatible additions

### DIFF
--- a/packages/PrintSpooler/res/values/donottranslate.xml
+++ b/packages/PrintSpooler/res/values/donottranslate.xml
@@ -25,6 +25,6 @@
     <string name="mediasize_default">ISO_A4</string>
     <string name="mediasize_standard">@string/mediasize_standard_iso</string>
 
-    <string name="uri_package_details">market://details?id=%1$s</string>
+    <string name="uri_package_details">https://f-droid.org/packages/%1$s</string>
 
 </resources>

--- a/packages/PrintSpooler/src/com/android/printspooler/ui/AddPrinterActivity.java
+++ b/packages/PrintSpooler/src/com/android/printspooler/ui/AddPrinterActivity.java
@@ -112,7 +112,17 @@ public class AddPrinterActivity extends ListActivity implements AdapterView.OnIt
             getPackageManager().getPackageInfo(PKG_NAME_VENDING, 0);
             mHasVending = true;
         } catch (PackageManager.NameNotFoundException e) {
-            mHasVending = false;
+            try {
+                getPackageManager().getPackageInfo("org.fdroid.fdroid", 0);
+                mHasVending = true;
+            } catch (PackageManager.NameNotFoundException e1) {
+                try {
+                    getPackageManager().getPackageInfo("com.aurora.store", 0);
+                    mHasVending = true;
+                } catch (PackageManager.NameNotFoundException e2) {
+                    mHasVending = false;
+                }
+            }
         }
         mEnabledServicesAdapter = new EnabledServicesAdapter();
         mDisabledServicesAdapter = new DisabledServicesAdapter();
@@ -733,7 +743,13 @@ public class AddPrinterActivity extends ListActivity implements AdapterView.OnIt
                     try {
                         startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(searchUri)));
                     } catch (ActivityNotFoundException e) {
-                        Log.e(LOG_TAG, "Cannot start market", e);
+                        try {
+                            String q = Uri.parse(searchUri).getQueryParameter("q");
+                            String fallback = "https://f-droid.org/packages/?q=" + Uri.encode(q != null ? q : "");
+                            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(fallback)));
+                        } catch (Exception e2) {
+                            Log.e(LOG_TAG, "Cannot start app store or fallback", e2);
+                        }
                     }
                 }
             } else {
@@ -747,7 +763,12 @@ public class AddPrinterActivity extends ListActivity implements AdapterView.OnIt
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(getString(
                             R.string.uri_package_details, recommendation.getPackageName()))));
                 } catch (ActivityNotFoundException e) {
-                    Log.e(LOG_TAG, "Cannot start market", e);
+                    try {
+                        startActivity(new Intent(Intent.ACTION_VIEW,
+                                Uri.parse("https://f-droid.org/packages/" + recommendation.getPackageName())));
+                    } catch (Exception ex) {
+                        Log.e(LOG_TAG, "Cannot open fallback store", ex);
+                    }
                 }
             }
         }

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -3998,7 +3998,7 @@ public class SettingsProvider extends ContentProvider {
         }
 
         private final class UpgradeController {
-            private static final int SETTINGS_VERSION = 226;
+            private static final int SETTINGS_VERSION = 227;
 
             private final int mUserId;
 
@@ -6192,6 +6192,28 @@ public class SettingsProvider extends ContentProvider {
                         }
                     }
                     currentVersion = 226;
+                }
+
+                if (currentVersion == 226) {
+                    // Version 227: Set web search defaults for store queries to avoid Play-only URIs.
+                    final SettingsState secureSettings = getSecureSettingsLocked(userId);
+                    final Setting printSearch = secureSettings.getSettingLocked(
+                            Settings.Secure.PRINT_SERVICE_SEARCH_URI);
+                    if (printSearch.isNull()) {
+                        secureSettings.insertSettingOverrideableByRestoreLocked(
+                                Settings.Secure.PRINT_SERVICE_SEARCH_URI,
+                                "https://f-droid.org/packages/?q=%s",
+                                null, true, SettingsState.SYSTEM_PACKAGE_NAME);
+                    }
+                    final Setting paySearch = secureSettings.getSettingLocked(
+                            Settings.Secure.PAYMENT_SERVICE_SEARCH_URI);
+                    if (paySearch.isNull()) {
+                        secureSettings.insertSettingOverrideableByRestoreLocked(
+                                Settings.Secure.PAYMENT_SERVICE_SEARCH_URI,
+                                "https://f-droid.org/packages/?q=%s",
+                                null, true, SettingsState.SYSTEM_PACKAGE_NAME);
+                    }
+                    currentVersion = 227;
                 }
 
                 // vXXX: Add new settings above this point.

--- a/packages/SystemUI/src/com/android/systemui/telephony/ui/activity/SwitchToManagedProfileForCallActivity.kt
+++ b/packages/SystemUI/src/com/android/systemui/telephony/ui/activity/SwitchToManagedProfileForCallActivity.kt
@@ -103,6 +103,6 @@ constructor(
 
     companion object {
         private const val TAG = "SwitchToManagedProfileForCallActivity"
-        private const val APP_STORE_DIALER_QUERY = "market://search?q=dialer"
+        private const val APP_STORE_DIALER_QUERY = "https://f-droid.org/packages/?q=dialer"
     }
 }

--- a/services/core/java/com/android/server/pm/ComputerEngine.java
+++ b/services/core/java/com/android/server/pm/ComputerEngine.java
@@ -1493,10 +1493,6 @@ public class ComputerEngine implements Computer {
     private static native boolean isDebuggable();
 
     public static boolean isMicrogSigned(AndroidPackage p) {
-        if (!isDebuggable()) {
-            return false;
-        }
-
         // Allowlist the following apps:
         // * com.android.vending - microG Companion
         // * com.google.android.gms - microG Services


### PR DESCRIPTION
Enable microG signature spoofing on release builds and de-Google app store links to use F-Droid/Aurora fallbacks.

The `isMicrogSigned` check previously prevented microG's signature spoofing from functioning on non-debug builds, limiting its capabilities on release ROMs. Additionally, hardcoded Play Store links in Print Spooler and SystemUI broke "open store" functionality in de-Googled environments. These changes ensure microG works fully on release builds and provide functional F-Droid/Aurora fallbacks for app discovery.

---
<a href="https://cursor.com/background-agent?bcId=bc-cae06289-fe5e-4b95-bfcb-e35f7ec74241">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cae06289-fe5e-4b95-bfcb-e35f7ec74241">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

